### PR TITLE
Support heartbeat 6.x

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -8,6 +8,15 @@ transport:
 
 provisioner:
   name: dokken
+  attributes:
+    heartbeat:
+      config:
+        output.elasticsearch:
+            hosts: ["127.0.0.1:9200"]
+        heartbeat.monitors:
+          - type: icmp
+            schedule: '*/5 * * * * * *'
+            hosts: ['127.0.0.1']
 
 # verifier:
 #  name: inspec
@@ -39,12 +48,9 @@ suites:
   - name: default
     run_list:
       - recipe[elastic-heartbeat::default]
+  - name: version_6
+    run_list:
+      - recipe[elastic-heartbeat::default]
     attributes:
       heartbeat:
-        config:
-          output.elasticsearch:
-              hosts: ["127.0.0.1:9200"]
-          heartbeat.monitors:
-            - type: icmp
-              schedule: '*/5 * * * * * *'
-              hosts: ['127.0.0.1']
+        version: '6.2.3'

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,15 @@ driver:
 
 provisioner:
   name: chef_zero
+  attributes:
+    heartbeat:
+      config:
+        output.elasticsearch:
+            hosts: ["127.0.0.1:9200"]
+        heartbeat.monitors:
+          - type: icmp
+            schedule: '*/5 * * * * * *'
+            hosts: ['127.0.0.1']
 
 platforms:
   - name: ubuntu-14.04
@@ -20,12 +29,9 @@ suites:
   - name: default
     run_list:
       - recipe[elastic-heartbeat::default]
+  - name: version_6
+    run_list:
+      - recipe[elastic-heartbeat::default]
     attributes:
       heartbeat:
-        config:
-          output.elasticsearch:
-              hosts: ["127.0.0.1:9200"]
-          heartbeat.monitors:
-            - type: icmp
-              schedule: '*/5 * * * * * *'
-              hosts: ['127.0.0.1']
+        version: '6.2.3'

--- a/recipes/attributes.rb
+++ b/recipes/attributes.rb
@@ -22,3 +22,12 @@ node.default['heartbeat']['yum']['baseurl'] = "https://artifacts.elastic.co/pack
 node.default['heartbeat']['yum']['gpgkey'] = 'https://artifacts.elastic.co/GPG-KEY-elasticsearch'
 node.default['heartbeat']['apt']['uri'] = "https://artifacts.elastic.co/packages/#{major_version}.x/apt"
 node.default['heartbeat']['apt']['key'] = 'https://artifacts.elastic.co/GPG-KEY-elasticsearch'
+
+# The package and service weren't namespaced with "-elastic" prior to 6.x
+if major_version.to_i < 6
+  node.default['heartbeat']['package_name'] = 'heartbeat'
+  node.default['heartbeat']['service_name'] = 'heartbeat'
+else
+  node.default['heartbeat']['package_name'] = 'heartbeat-elastic'
+  node.default['heartbeat']['service_name'] = 'heartbeat-elastic'
+end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -37,6 +37,7 @@ end
 service_action = node['heartbeat']['disable_service'] ? [:disable, :stop] : [:enable, :nothing]
 
 service 'heartbeat' do
+  service_name node['heartbeat']['service_name']
   provider Chef::Provider::Service::Solaris if node['platform_family'] == 'solaris2'
   retries node['heartbeat']['service']['retries']
   retry_delay node['heartbeat']['service']['retry_delay']

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -33,7 +33,7 @@ when 'debian'
   end
 
   unless node['heartbeat']['ignore_version'] # ~FC023
-    apt_preference 'heartbeat' do
+    apt_preference node['heartbeat']['package_name'] do
       pin          "version #{node['heartbeat']['version']}"
       pin_priority '700'
     end
@@ -52,7 +52,7 @@ when 'rhel'
   end
 
   unless node['heartbeat']['ignore_version'] # ~FC023
-    yum_version_lock 'heartbeat' do
+    yum_version_lock node['heartbeat']['package_name'] do
       version node['heartbeat']['version']
       release node['heartbeat']['release']
       action :update
@@ -60,7 +60,7 @@ when 'rhel'
   end
 end
 
-package 'heartbeat' do # ~FC009
+package node['heartbeat']['package_name'] do # ~FC009
   version version_string unless node['heartbeat']['ignore_version']
   options node['heartbeat']['apt']['options'] if node['heartbeat']['apt']['options'] && node['platform_family'] == 'debian'
   notifies :restart, 'service[heartbeat]' if node['heartbeat']['notify_restart'] && !node['heartbeat']['disable_service']


### PR DESCRIPTION
Due to a naming conflict on Debian, the package and service were namespaced from 6.0 onwards.  This adds two new attributes and sets defaults accordingly.

See https://github.com/elastic/beats/pull/4601