### PR TITLE
Use elastic_beats_repo cookbook for managing repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This cookbook was tested on CentOS & Ubuntu Linux and expected to work on other 
 
 * `default['heartbeat']['monitors_dir']` (default: `/etc/heartbeat/conf.d`): monitors configuration file directory
 
+* `default['heartbeat']['setup_repo']` (default: `true`): whether to manage the beats apt/yum repository
 
 ## Contributing
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,8 +1,6 @@
 default['heartbeat']['version'] = '5.2.2'
 default['heartbeat']['release'] = '1'
 default['heartbeat']['disable_service'] = false
-default['heartbeat']['package_url'] = 'auto'
-default['heartbeat']['package_force_overwrite'] = true
 default['heartbeat']['setup_repo'] = true
 
 default['heartbeat']['ignore_version'] = false
@@ -11,8 +9,6 @@ default['heartbeat']['notify_restart'] = true
 default['heartbeat']['service']['init_style'] = 'init' # or runit
 default['heartbeat']['service']['retries'] = 0
 default['heartbeat']['service']['retry_delay'] = 2
-
-default['heartbeat']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? 'x86_64' : 'x86'
 
 default['heartbeat']['conf_dir'] = '/etc/heartbeat'
 default['heartbeat']['conf_file'] = ::File.join(node['heartbeat']['conf_dir'], 'heartbeat.yml')

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,7 @@ default['heartbeat']['release'] = '1'
 default['heartbeat']['disable_service'] = false
 default['heartbeat']['package_url'] = 'auto'
 default['heartbeat']['package_force_overwrite'] = true
+default['heartbeat']['setup_repo'] = true
 
 default['heartbeat']['ignore_version'] = false
 default['heartbeat']['notify_restart'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ source_url 'https://github.com/vkhatri/chef-heartbeat' if respond_to?(:source_ur
 issues_url 'https://github.com/vkhatri/chef-heartbeat/issues' if respond_to?(:issues_url)
 
 depends 'apt'
+depends 'elastic_beats_repo'
 depends 'yum'
 depends 'yum-plugin-versionlock', '>= 0.1.2'
 

--- a/recipes/attributes.rb
+++ b/recipes/attributes.rb
@@ -18,7 +18,4 @@
 #
 
 major_version = node['heartbeat']['version'].split('.')[0]
-node.default['heartbeat']['yum']['baseurl'] = "https://artifacts.elastic.co/packages/#{major_version}.x/yum"
-node.default['heartbeat']['yum']['gpgkey'] = 'https://artifacts.elastic.co/GPG-KEY-elasticsearch'
-node.default['heartbeat']['apt']['uri'] = "https://artifacts.elastic.co/packages/#{major_version}.x/apt"
-node.default['heartbeat']['apt']['key'] = 'https://artifacts.elastic.co/GPG-KEY-elasticsearch'
+node.default['elastic_beats_repo']['version'] = node['heartbeat']['version'] if node['heartbeat']['setup_repo']

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -21,16 +21,7 @@ version_string = node['platform_family'] == 'rhel' ? "#{node['heartbeat']['versi
 
 case node['platform_family']
 when 'debian'
-  package 'apt-transport-https'
-
-  # apt repository configuration
-  apt_repository 'beats' do
-    uri node['heartbeat']['apt']['uri']
-    components node['heartbeat']['apt']['components']
-    key node['heartbeat']['apt']['key']
-    distribution node['heartbeat']['apt']['distribution']
-    action node['heartbeat']['apt']['action']
-  end
+  include_recipe 'elastic_beats_repo::apt' if node['heartbeat']['setup_repo']
 
   unless node['heartbeat']['ignore_version'] # ~FC023
     apt_preference 'heartbeat' do
@@ -38,18 +29,8 @@ when 'debian'
       pin_priority '700'
     end
   end
-
-when 'rhel'
-  # yum repository configuration
-  yum_repository 'beats' do
-    description node['heartbeat']['yum']['description']
-    baseurl node['heartbeat']['yum']['baseurl']
-    gpgcheck node['heartbeat']['yum']['gpgcheck']
-    gpgkey node['heartbeat']['yum']['gpgkey']
-    enabled node['heartbeat']['yum']['enabled']
-    metadata_expire node['heartbeat']['yum']['metadata_expire']
-    action node['heartbeat']['yum']['action']
-  end
+when 'fedora', 'rhel', 'amazon'
+  include_recipe 'elastic_beats_repo::yum' if node['heartbeat']['setup_repo']
 
   unless node['heartbeat']['ignore_version'] # ~FC023
     yum_version_lock 'heartbeat' do


### PR DESCRIPTION
This makes the `elastic_beats_repo` cookbook responsible for managing the repo.  Also adds an attribute for users that wish to manage the repository themselves via a wrapper cookbook.